### PR TITLE
Fix broken dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject microservice-app "0.1.0-SNAPSHOT"
  :description "My microservice"
  :dependencies [[org.clojure/clojure "1.10.1"]
-                [metosin/compojure-api "1.1.11"]]
+                [metosin/compojure-api "2.0.0-alpha30"]]
  :ring {:handler myservice.app/app :port 8080}
  :min-lein-version "2.0.0"
  :uberjar-name "microservice"

--- a/src/myservice/app.clj
+++ b/src/myservice/app.clj
@@ -10,11 +10,11 @@
 (s/defschema UserResponse
   {:message s/Str})
 
-(defapi app
+(def app (api
     (GET "/health" []
       (ok "OK"))
 
     (POST "/message" []
       :body [{:keys [name]} User]
       :return UserResponse
-      (ok {:message (str "Hello " name)})))
+      (ok {:message (str "Hello " name)}))))


### PR DESCRIPTION
I'm not exactly sure what is going on here, and this shouldn't be treated as if I understand what I think the solution should be, just an indicator for you @wilzbach as to a potential way forward.

I don't really understand clojure's dependency system, but since the dockerfile is using a tagged image, and the build started breaking without any changes, it would seem somewhere down the dependency tree something changed.

At a quick glance it seems like everything is explicitly pinned by `project.clj` files, but I'm not sure if that's a rule and I certainly didn't look through all the sub dependencies. If it's not we should probably vendor or freeze all the deps as shown by `lein deps :tree`.

Good luck!